### PR TITLE
fix import order

### DIFF
--- a/rpmlint/AbstractCheck.py
+++ b/rpmlint/AbstractCheck.py
@@ -14,8 +14,8 @@ try:
 except ImportError:
     import urllib.request as urllib2
 
-from . import Config
-from .Filter import addDetails, printInfo, printWarning
+import rpmlint.Config as Config
+from rpmlint.Filter import addDetails, printInfo, printWarning
 
 # Note: do not add any capturing parentheses here
 macro_regex = re.compile(r'%+[{(]?[a-zA-Z_]\w{2,}[)}]?')

--- a/rpmlint/AppDataCheck.py
+++ b/rpmlint/AppDataCheck.py
@@ -8,10 +8,10 @@
 
 import xml.etree.ElementTree as ET
 
-from . import AbstractCheck
-from . import Config
-from .Filter import addDetails, printError
-from .Pkg import getstatusoutput
+import rpmlint.AbstractCheck as AbstractCheck
+import rpmlint.Config as Config
+from rpmlint.Filter import addDetails, printError
+from rpmlint.Pkg import getstatusoutput
 
 STANDARD_BIN_DIRS = ['/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/']
 DEFAULT_APPDATA_CHECKER = ('appstream-util', 'validate-relax')

--- a/rpmlint/BinariesCheck.py
+++ b/rpmlint/BinariesCheck.py
@@ -14,10 +14,10 @@ import subprocess
 
 import rpm
 
-from . import AbstractCheck
-from . import Config
-from . import Pkg
-from .Filter import addDetails, printError, printWarning
+import rpmlint.AbstractCheck as AbstractCheck
+import rpmlint.Config as Config
+import rpmlint.Pkg as Pkg
+from rpmlint.Filter import addDetails, printError, printWarning
 
 
 DEFAULT_SYSTEM_LIB_PATHS = (

--- a/rpmlint/Config.py
+++ b/rpmlint/Config.py
@@ -12,7 +12,7 @@ import os.path
 import re
 
 try:
-    from . import __version__
+    import __version__
 except ImportError:
     __version__ = 'devel'
 

--- a/rpmlint/ConfigCheck.py
+++ b/rpmlint/ConfigCheck.py
@@ -7,8 +7,8 @@
 # Purpose       :
 #############################################################################
 
-from . import AbstractCheck
-from .Filter import addDetails, printError, printWarning
+import rpmlint.AbstractCheck as AbstractCheck
+from rpmlint.Filter import addDetails, printError, printWarning
 
 
 class ConfigCheck(AbstractCheck.AbstractCheck):

--- a/rpmlint/DistributionCheck.py
+++ b/rpmlint/DistributionCheck.py
@@ -11,9 +11,9 @@ import re
 
 import rpm
 
-from . import AbstractCheck
-from . import Config
-from .Filter import addDetails, printWarning
+import rpmlint.AbstractCheck as AbstractCheck
+import rpmlint.Config as Config
+from rpmlint.Filter import addDetails, printWarning
 
 
 man_regex = re.compile(r"/man(?:\d[px]?|n)/")

--- a/rpmlint/DocFilesCheck.py
+++ b/rpmlint/DocFilesCheck.py
@@ -16,9 +16,9 @@
 
 import rpm
 
-from . import AbstractCheck
-from .Filter import addDetails, printWarning
-from .Pkg import b2s
+import rpmlint.AbstractCheck as AbstractCheck
+from rpmlint.Filter import addDetails, printWarning
+from rpmlint.Pkg import b2s
 
 
 class DocFilesCheck(AbstractCheck.AbstractCheck):

--- a/rpmlint/FHSCheck.py
+++ b/rpmlint/FHSCheck.py
@@ -9,8 +9,8 @@
 
 import re
 
-from . import AbstractCheck
-from .Filter import addDetails, printWarning
+import rpmlint.AbstractCheck as AbstractCheck
+from rpmlint.Filter import addDetails, printWarning
 
 
 class FHSCheck(AbstractCheck.AbstractCheck):

--- a/rpmlint/FilesCheck.py
+++ b/rpmlint/FilesCheck.py
@@ -15,10 +15,10 @@ import stat
 
 import rpm
 
-from . import AbstractCheck
-from . import Config
-from .Filter import addDetails, printError, printWarning
-from .Pkg import b2s, catcmd, getstatusoutput, is_utf8, is_utf8_bytestr, shquote
+import rpmlint.AbstractCheck as AbstractCheck
+import rpmlint.Config as Config
+from rpmlint.Filter import addDetails, printError, printWarning
+from rpmlint.Pkg import b2s, catcmd, getstatusoutput, is_utf8, is_utf8_bytestr, shquote
 
 
 # must be kept in sync with the filesystem package

--- a/rpmlint/Filter.py
+++ b/rpmlint/Filter.py
@@ -13,7 +13,7 @@ import locale
 import sys
 import textwrap
 
-from . import Config
+import rpmlint.Config as Config
 try:
     import Testing
 except ImportError:

--- a/rpmlint/I18NCheck.py
+++ b/rpmlint/I18NCheck.py
@@ -11,9 +11,9 @@ import re
 
 import rpm
 
-from . import AbstractCheck
-from .__isocodes__ import COUNTRIES, LANGUAGES
-from .Filter import addDetails, printError, printWarning
+import rpmlint.AbstractCheck as AbstractCheck
+from rpmlint.__isocodes__ import COUNTRIES, LANGUAGES
+from rpmlint.Filter import addDetails, printError, printWarning
 
 
 # Associative array of invalid value => correct value

--- a/rpmlint/InitScriptCheck.py
+++ b/rpmlint/InitScriptCheck.py
@@ -13,10 +13,10 @@ import re
 
 import rpm
 
-from . import AbstractCheck
-from . import Config
-from . import Pkg
-from .Filter import addDetails, printError, printWarning
+import rpmlint.AbstractCheck as AbstractCheck
+import rpmlint.Config as Config
+import rpmlint.Pkg as Pkg
+from rpmlint.Filter import addDetails, printError, printWarning
 
 
 chkconfig_content_regex = re.compile(r'^\s*#\s*chkconfig:\s*([-0-9]+)\s+[-0-9]+\s+[-0-9]+')

--- a/rpmlint/LSBCheck.py
+++ b/rpmlint/LSBCheck.py
@@ -12,8 +12,8 @@ import re
 
 import rpm
 
-from . import AbstractCheck
-from .Filter import addDetails, printError
+import AbstractCheck
+from Filter import addDetails, printError
 
 
 version_regex = re.compile('^[a-zA-Z0-9.+]+$')

--- a/rpmlint/MenuCheck.py
+++ b/rpmlint/MenuCheck.py
@@ -12,10 +12,10 @@ import stat
 
 import rpm
 
-from . import AbstractCheck
-from . import Config
-from . import Pkg
-from .Filter import addDetails, printError, printInfo, printWarning
+import rpmlint.AbstractCheck as AbstractCheck
+import rpmlint.Config as Config
+import rpmlint.Pkg as Pkg
+from rpmlint.Filter import addDetails, printError, printInfo, printWarning
 
 
 DEFAULT_VALID_SECTIONS = (

--- a/rpmlint/MenuXDGCheck.py
+++ b/rpmlint/MenuXDGCheck.py
@@ -13,9 +13,9 @@ try:
 except ImportError:
     import configparser as cfgparser
 
-from . import AbstractCheck
-from .Filter import addDetails, printError, printWarning
-from .Pkg import getstatusoutput, is_utf8
+import rpmlint.AbstractCheck as AbstractCheck
+from rpmlint.Filter import addDetails, printError, printWarning
+from rpmlint.Pkg import getstatusoutput, is_utf8
 
 STANDARD_BIN_DIRS = ('/bin', '/sbin', '/usr/bin', '/usr/sbin')
 

--- a/rpmlint/NamingPolicyCheck.py
+++ b/rpmlint/NamingPolicyCheck.py
@@ -10,8 +10,8 @@
 
 import re
 
-from . import AbstractCheck
-from .Filter import addDetails, printWarning
+import rpmlint.AbstractCheck as AbstractCheck
+from rpmlint.Filter import addDetails, printWarning
 
 # could be added.
 #

--- a/rpmlint/PamCheck.py
+++ b/rpmlint/PamCheck.py
@@ -10,8 +10,8 @@
 
 import re
 
-from . import AbstractCheck
-from .Filter import addDetails, printError
+import rpmlint.AbstractCheck as AbstractCheck
+from rpmlint.Filter import addDetails, printError
 
 
 pam_stack_re = re.compile(r'^\s*[^#].*pam_stack\.so\s*service')

--- a/rpmlint/Pkg.py
+++ b/rpmlint/Pkg.py
@@ -31,7 +31,7 @@ except ImportError:
     _magic = None
 import rpm
 
-from . import Filter
+import rpmlint.Filter
 
 # utilities
 

--- a/rpmlint/PostCheck.py
+++ b/rpmlint/PostCheck.py
@@ -14,10 +14,10 @@ import tempfile
 
 import rpm
 
-from . import AbstractCheck
-from . import Config
-from . import Pkg
-from .Filter import addDetails, printError, printWarning
+import rpmlint.AbstractCheck as AbstractCheck
+import rpmlint.Config as Config
+import rpmlint.Pkg as Pkg
+from rpmlint.Filter import addDetails, printError, printWarning
 
 
 DEFAULT_VALID_SHELLS = ('<lua>',

--- a/rpmlint/RpmFileCheck.py
+++ b/rpmlint/RpmFileCheck.py
@@ -20,8 +20,8 @@
 
 import os
 
-from . import AbstractCheck
-from .Filter import addDetails, printWarning
+import rpmlint.AbstractCheck as AbstractCheck
+from rpmlint.Filter import addDetails, printWarning
 
 
 class RpmFileCheck(AbstractCheck.AbstractCheck):

--- a/rpmlint/SCLCheck.py
+++ b/rpmlint/SCLCheck.py
@@ -10,9 +10,9 @@
 import os
 import re
 
-from . import AbstractCheck
-from . import Pkg
-from .Filter import addDetails, printError, printWarning
+import rpmlint.AbstractCheck as AbstractCheck
+import rpmlint.Pkg as Pkg
+from rpmlint.Filter import addDetails, printError, printWarning
 
 
 # Compile all regexes here

--- a/rpmlint/SignatureCheck.py
+++ b/rpmlint/SignatureCheck.py
@@ -9,9 +9,9 @@
 
 import re
 
-from . import AbstractCheck
-from . import Pkg
-from .Filter import addDetails, printError
+import rpmlint.AbstractCheck as AbstractCheck
+import rpmlint.Pkg as Pkg
+from rpmlint.Filter import addDetails, printError
 
 
 class SignatureCheck(AbstractCheck.AbstractCheck):

--- a/rpmlint/SourceCheck.py
+++ b/rpmlint/SourceCheck.py
@@ -9,9 +9,9 @@
 
 import re
 
-from . import AbstractCheck
-from . import Config
-from .Filter import addDetails, printError, printWarning
+import rpmlint.AbstractCheck as AbstractCheck
+import rpmlint.Config as Config
+from rpmlint.Filter import addDetails, printError, printWarning
 
 
 DEFAULT_VALID_SRC_PERMS = (0o644, 0o755)

--- a/rpmlint/SpecCheck.py
+++ b/rpmlint/SpecCheck.py
@@ -16,11 +16,11 @@ except ImportError:  # Python 3
 
 import rpm
 
-from . import AbstractCheck
-from . import Config
-from . import Pkg
-from .Filter import addDetails, printError, printWarning
-from .TagsCheck import VALID_GROUPS
+import rpmlint.AbstractCheck as AbstractCheck
+import rpmlint.Config as Config
+import rpmlint.Pkg as Pkg
+from rpmlint.Filter import addDetails, printError, printWarning
+from rpmlint.TagsCheck import VALID_GROUPS
 
 # Don't check for hardcoded library paths in biarch packages
 DEFAULT_BIARCH_PACKAGES = '^(gcc|glibc)'

--- a/rpmlint/TagsCheck.py
+++ b/rpmlint/TagsCheck.py
@@ -18,11 +18,11 @@ except ImportError:  # Python 3
 
 import rpm
 
-from . import AbstractCheck
-from . import Config
-from . import FilesCheck
-from . import Pkg
-from .Filter import addDetails, printError, printInfo, printWarning
+import rpmlint.AbstractCheck as AbstractCheck
+import rpmlint.Config as Config
+import rpmlint.FilesCheck as FilesCheck
+import rpmlint.Pkg as Pkg
+from rpmlint.Filter import addDetails, printError, printInfo, printWarning
 
 
 _use_enchant = Config.getOption("UseEnchant", None)

--- a/rpmlint/ZipCheck.py
+++ b/rpmlint/ZipCheck.py
@@ -13,10 +13,10 @@ import stat
 import sys
 import zipfile
 
-from . import AbstractCheck
-from . import Config
-from . import Pkg
-from .Filter import addDetails, printError, printWarning
+import rpmlint.AbstractCheck as AbstractCheck
+import rpmlint.Config as Config
+import rpmlint.Pkg as Pkg
+from rpmlint.Filter import addDetails, printError, printWarning
 
 
 zip_regex = re.compile(r'\.(zip|[ewj]ar)$')

--- a/scripts/diff.py
+++ b/scripts/diff.py
@@ -24,7 +24,7 @@ import sys
 import tempfile
 
 import rpm
-from rpmlint import Pkg
+import rpmlint.Pkg
 
 
 class Rpmdiff(object):

--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -30,9 +30,9 @@ except ImportError:  # Python < 2.7
 # loaded which is too early - settings from config files won't take
 # place for those variables.
 
-from rpmlint import AbstractCheck
-from rpmlint import Config
-from rpmlint import Pkg
+import rpmlint.AbstractCheck
+import rpmlint.Config as Config
+import rpmlint.Pkg as Pkg
 from rpmlint.Filter import badnessScore, badnessThreshold, printAllReasons, \
     printDescriptions, printed_messages, printInfo, setRawOut
 


### PR DESCRIPTION
The mix of relative paths seems to change
the Config include order which breaks testing
because the config global variables are reinitialized.

The non-relative imports are imho easier to read
anyway, and they give opportunity to make the rest
of the code more readable by removing the "as XXX"
renames in a followup commit.